### PR TITLE
Change package Id from KDE to GitHub namespace

### DIFF
--- a/package/metadata.json
+++ b/package/metadata.json
@@ -10,7 +10,7 @@
         "Category": "System Information",
         "Description": "Pipewire quantum and sample rate settings",
         "Icon": "audio",
-        "Id": "org.kde.plasma.pipewiresettings",
+        "Id": "com.github.magillos.pipewiresettings",
         "License": "GPL-3.0-or-later",
         "Name": "Pipewire Settings",
         "ServiceTypes": [


### PR DESCRIPTION
The kde namespace cannot be used for third-party plasmoids like this.